### PR TITLE
feat(ci): use commitlint instead of agenthunt

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,8 +6,21 @@ on:
     types: [opened, edited, synchronize]
 
 jobs:
-  check-for-cc:
+  conventional-commit:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for conventional commits
-        uses: agenthunt/conventional-commit-checker-action@v1.0.0
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install dependencies
+        run: npm install @commitlint/config-conventional
+      - name: Configure commitlint
+        run: |
+          echo "module.exports = {extends: ['@commitlint/config-conventional']};" > commitlint.config.js
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v5
+        env:
+          NODE_PATH: ${{ github.workspace }}/node_modules


### PR DESCRIPTION
This PR edits the check ci to use commitlint instead of agenthunt.